### PR TITLE
Updated section on SCT usage by AS and VS.

### DIFF
--- a/draft-wendt-stir-certificate-transparency.md
+++ b/draft-wendt-stir-certificate-transparency.md
@@ -611,7 +611,7 @@ Upon receipt of a SIP INVITE bearing an Identity header, the VS performs the ste
    - Ensure now() >= SCT.timestamp **or** defer to asynchronous auditor.
    - If any SCT fails, mark call as “failed verification” per {{ATIS-1000074}} and optionally populate verstat=f
 
-Implementations SHOULD cache Certificates and validated SCT objects for the lifetime of the Certificates’s notAfter field to amortize step 3 across many calls.
+Implementations SHOULD cache certificates and validated SCT objects for the lifetime of the certificates' notAfter field to amortize step 3 across many calls.
 
 ### Performance and Scalability Guidelines
 

--- a/draft-wendt-stir-certificate-transparency.md
+++ b/draft-wendt-stir-certificate-transparency.md
@@ -608,7 +608,7 @@ Upon receipt of a SIP INVITE bearing an Identity header, the VS performs the ste
 2. Validate DC chain to an accepted STI trust anchor.
 3. For every embedded SCT:
    - Verify signature against cached log key.
-   - Ensure now() ≥ SCT.timestamp **or** defer to asynchronous auditor.
+   - Ensure now() >= SCT.timestamp **or** defer to asynchronous auditor.
    - If any SCT fails, mark call as “failed verification” per {{ATIS-1000074}} and optionally populate verstat=f
 
 Implementations SHOULD cache Certificates and validated SCT objects for the lifetime of the Certificates’s notAfter field to amortize step 3 across many calls.


### PR DESCRIPTION
This PR updates section "Use of SCTs by Authentication and Verification Services" of the draft, detailing how Authentication Services (AS) and Verification Services (VS) utilize Signed Certificate Timestamps (SCTs) within the STIR framework. The addition emphasizes the exclusive use of the pre-chain method, where SCTs are embedded directly into certificates, and highlights the importance of rapid verification in telephony.

**Key Changes:**
- Added a dedicated section explaining the roles of AS and VS concerning SCTs.
- Clarified the use of the pre-chain method for embedding SCTs into delegate certificates.
- Discussed performance considerations, focusing on the necessity for swift verification in call authentication processes.

Closes #4 