### PR TITLE
Update draft-wendt-stir-certificate-transparency.md

### DIFF
--- a/draft-wendt-stir-certificate-transparency.md
+++ b/draft-wendt-stir-certificate-transparency.md
@@ -213,10 +213,9 @@ Upon receipt of a SIP INVITE bearing an Identity header, the VS performs the ste
 
 1. Verify PASSporT signature with DC public key
 2. Validate DC chain to an accepted STI trust anchor.
-3. For every embedded SCT:
+3. For each embedded SCT:
    - Verify signature against cached log key.
    - Ensure now() >= SCT.timestamp **or** defer to asynchronous auditor.
-   - If any SCT fails, the verification should also be considered failed. 
 
 Implementations SHOULD cache certificates and validated SCT objects for the lifetime of the certificates' notAfter field to amortize step 3 across many calls.
 

--- a/draft-wendt-stir-certificate-transparency.md
+++ b/draft-wendt-stir-certificate-transparency.md
@@ -211,7 +211,7 @@ Because the SCT is delivered in-band with the Certificate, neither the AS nor th
 
 Upon receipt of a SIP INVITE bearing an Identity header, the VS performs the steps below, all of which are deliberately offline to avoid adding call-path latency:
 
-1. Verify PASSporT signature with DC public key
+1. Verify PASSporT signature with DC public key.
 2. Validate DC chain to an accepted STI trust anchor.
 3. For each embedded SCT:
    - Verify signature against cached log key.


### PR DESCRIPTION
The certificate may contain multiple SCTs from different logs. The VS may only trust some of the logs. It is also possible that one of the logs is compromised, discontinued, or otherwise no longer available.

The VS should have a local policy that defines how many verified SCTs a certificate must have to be trusted. If a certificate contains additional SCTs, whether verified or not, it should still be considered trusted so long as it meets the VS's policy.